### PR TITLE
Add add_remote_device tool to allow remote Frida connections

### DIFF
--- a/src/frida_mcp/cli.py
+++ b/src/frida_mcp/cli.py
@@ -177,7 +177,7 @@ def remove_remote_device(
         manager.remove_remote_device(address)
         return {"success": True, "address": address}
     except Exception as e:
-        raise ValueError(f"Failed to remove remote device at {host}:{port}: {str(e)}")
+        raise ValueError(f"Failed to remove remote device at {host}:{port}: {str(e)}") from e
 
 
 @mcp.tool()

--- a/src/frida_mcp/cli.py
+++ b/src/frida_mcp/cli.py
@@ -7,6 +7,7 @@ It sets up a basic Frida MCP server with STDIO transport for Claude to communica
 """
 
 import sys
+import ipaddress
 import frida
 from mcp.server.fastmcp import FastMCP, Context
 from typing import Dict, List, Optional, Any, Union
@@ -119,6 +120,18 @@ def get_local_device() -> Dict[str, Any]:
         raise ValueError("No local device found or error accessing it.")
 
 
+def _format_address(host: str, port: int) -> str:
+    """Format a host:port address string, correctly bracketing IPv6 addresses."""
+    bare = host.strip("[]")
+    try:
+        addr = ipaddress.ip_address(bare)
+        if isinstance(addr, ipaddress.IPv6Address):
+            return f"[{bare}]:{port}"
+    except ValueError:
+        pass
+    return f"{bare}:{port}"
+
+
 @mcp.tool()
 def add_remote_device(
     host: str = Field(description="The hostname or IP address of the remote Frida server (e.g. '192.168.1.100' or 'myhost')."),
@@ -137,7 +150,7 @@ def add_remote_device(
         Information about the remote device including its device_id
     """
     try:
-        address = f"{host}:{port}"
+        address = _format_address(host, port)
         manager = frida.get_device_manager()
 
         kwargs: Dict[str, Any] = {}
@@ -158,7 +171,7 @@ def add_remote_device(
             "address": address,
         }
     except Exception as e:
-        raise ValueError(f"Failed to add remote device at {host}:{port}: {str(e)}")
+        raise ValueError(f"Failed to add remote device at {host}:{port}: {str(e)}") from e
 
 
 @mcp.tool()
@@ -172,7 +185,7 @@ def remove_remote_device(
         Status information
     """
     try:
-        address = f"{host}:{port}"
+        address = _format_address(host, port)
         manager = frida.get_device_manager()
         manager.remove_remote_device(address)
         return {"success": True, "address": address}

--- a/src/frida_mcp/cli.py
+++ b/src/frida_mcp/cli.py
@@ -171,7 +171,7 @@ def add_remote_device(
             "address": address,
         }
     except Exception as e:
-        raise ValueError(f"Failed to add remote device at {host}:{port}: {str(e)}") from e
+        raise ValueError(f"Failed to add remote device at {_format_address(host, port)}: {str(e)}") from e
 
 
 @mcp.tool()
@@ -190,7 +190,7 @@ def remove_remote_device(
         manager.remove_remote_device(address)
         return {"success": True, "address": address}
     except Exception as e:
-        raise ValueError(f"Failed to remove remote device at {host}:{port}: {str(e)}") from e
+        raise ValueError(f"Failed to remove remote device at {_format_address(host, port)}: {str(e)}") from e
 
 
 @mcp.tool()

--- a/src/frida_mcp/cli.py
+++ b/src/frida_mcp/cli.py
@@ -120,6 +120,67 @@ def get_local_device() -> Dict[str, Any]:
 
 
 @mcp.tool()
+def add_remote_device(
+    host: str = Field(description="The hostname or IP address of the remote Frida server (e.g. '192.168.1.100' or 'myhost')."),
+    port: int = Field(default=27042, description="The port of the remote Frida server. Defaults to 27042."),
+    certificate: Optional[str] = Field(default=None, description="Optional TLS certificate to use for the connection."),
+    origin: Optional[str] = Field(default=None, description="Optional origin header to use for the connection."),
+    token: Optional[str] = Field(default=None, description="Optional authentication token for the remote device."),
+    keepalive_interval: Optional[int] = Field(default=None, description="Optional keepalive interval in seconds.")
+) -> Dict[str, Any]:
+    """Connect to a remote Frida server by hostname and port.
+
+    Once added, the remote device will appear in enumerate_devices() and can be
+    referenced by its device_id in all other tools.
+
+    Returns:
+        Information about the remote device including its device_id
+    """
+    try:
+        address = f"{host}:{port}"
+        manager = frida.get_device_manager()
+
+        kwargs: Dict[str, Any] = {}
+        if certificate is not None:
+            kwargs["certificate"] = certificate
+        if origin is not None:
+            kwargs["origin"] = origin
+        if token is not None:
+            kwargs["token"] = token
+        if keepalive_interval is not None:
+            kwargs["keepalive_interval"] = keepalive_interval
+
+        device = manager.add_remote_device(address, **kwargs)
+        return {
+            "id": device.id,
+            "name": device.name,
+            "type": device.type,
+            "address": address,
+        }
+    except Exception as e:
+        raise ValueError(f"Failed to add remote device at {host}:{port}: {str(e)}")
+
+
+@mcp.tool()
+def remove_remote_device(
+    host: str = Field(description="The hostname or IP address of the remote Frida server to disconnect from."),
+    port: int = Field(default=27042, description="The port of the remote Frida server. Defaults to 27042.")
+) -> Dict[str, Any]:
+    """Disconnect from a previously added remote Frida server.
+
+    Returns:
+        Status information
+    """
+    try:
+        address = f"{host}:{port}"
+        manager = frida.get_device_manager()
+        manager.remove_remote_device(address)
+        return {"success": True, "address": address}
+    except Exception as e:
+        raise ValueError(f"Failed to remove remote device at {host}:{port}: {str(e)}")
+
+
+@mcp.tool()
 def get_process_by_name(name: str = Field(description="The name (or part of the name) of the process to find. Case-insensitive."),
                        device_id: Optional[str] = Field(default=None, description="Optional ID of the device to search the process on. Uses USB device if not specified.")) -> dict:
     """Find a process by name."""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new network-facing capability to connect/disconnect from remote Frida servers (including optional auth/TLS parameters), which can affect connectivity and security assumptions if misused or misconfigured.
> 
> **Overview**
> Adds MCP tools to manage remote Frida connections from the CLI: `add_remote_device` (with optional `certificate`, `origin`, `token`, and `keepalive_interval`) and `remove_remote_device`.
> 
> Introduces `_format_address` using `ipaddress` to correctly format IPv4/hostname vs IPv6 (`[addr]:port`) when building the Frida remote device address, and surfaces remote device info (including `address`) or consistent `ValueError` errors on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7474b0a5ba24032c17c470a9b4e2a0878d5d7f86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->